### PR TITLE
Clean xcconfig references while deintegrating a target

### DIFF
--- a/lib/cocoapods/deintegrator.rb
+++ b/lib/cocoapods/deintegrator.rb
@@ -23,6 +23,9 @@ module Pod
         deintegrate_shell_script_phase(target, 'Check Pods Manifest.lock')
         deintegrate_shell_script_phase(target, 'Embed Pods Frameworks')
         deintegrate_pods_libraries(target)
+        target.build_configurations.each do |config|
+          config.base_configuration_reference.remove_from_project
+        end
       end
     end
 

--- a/spec/command/deintegrate_spec.rb
+++ b/spec/command/deintegrate_spec.rb
@@ -57,5 +57,17 @@ module Pod
     it 'deintegrates a framework integrated project' do
       deintegrate_project('Frameworks')
     end
+
+    it 'deintegrates a particular target' do
+      path = fixture_project('StaticLibraries/TestProject.xcodeproj')
+      project = Xcodeproj::Project.open(path)
+      target = project.native_targets.find { |t| t.name == 'TestProject' }
+      deintegrator = Deintegrator.new
+      deintegrator.deintegrate_target(target)
+
+      target.frameworks_build_phase.files.select { |f| f.display_name =~ /Pods/ }.should.be.empty
+      target.shell_script_build_phases.select { |p| p.name =~ /Pods/ }.should.be.empty
+      target.build_configurations.reject { |c| c.base_configuration_reference.nil? }.should.be.empty
+    end
   end
 end


### PR DESCRIPTION
Completes CocoaPods/CocoaPods#4544.

Currently `Deintegrator#deintegrate_target` method does not remove xcconfig file references for given target. Now we are sure that a target is completely deintegrated when `deintegrate_target` method is called.