### PR TITLE
Use a string literal instead of a constant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ branches:
 before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
-  - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.13"; else gem install "bundler:~> 1.13"; fi
+  - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.16" --conservative; else gem install "bundler:~> 1.16" --conservative; fi
   # RubyGems 2.0.14 isn't a fun time on 2.0.0p451
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem update --system; fi

--- a/lib/cocoapods/deintegrator.rb
+++ b/lib/cocoapods/deintegrator.rb
@@ -55,8 +55,8 @@ module Pod
 
     def deintegrate_user_shell_script_phases(target)
       user_script_phases = target.shell_script_build_phases.select do |phase|
-        !phase.name.nil? &&
-          phase.name.start_with?(Pod::Installer::UserProjectIntegrator::TargetIntegrator::USER_BUILD_PHASE_PREFIX)
+        next unless phase.name
+        phase.name.start_with?('[CP-User] ')
       end
 
       unless user_script_phases.empty?


### PR DESCRIPTION
This way, we remain compatible with versions of CocoaPods that dont have the constant